### PR TITLE
check for no options in destroy()

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,10 @@ RedisDown.prototype.iterator = function (options) {
  * Callbacks
  */
 RedisDown.destroy = function (location, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
   var client = redisLib.createClient(options.post, options.host, options);
   client.del(location, function(e) {
     client.quit();


### PR DESCRIPTION
`options` are optional for the `destroy()` method, so we get an 'undefined is not a function' when testing in the [PouchDB Server](https://github.com/pouchdb/pouchdb-server) test suite. This fixes that.
