### PR TITLE
Fixed an iterator bug for keys with non standard binary values...

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -186,11 +186,11 @@ Iterator.prototype._fetch = function(callback) {
     if (self._buffered.length) {
       // update _start for the next page fetch
       if (!self._keys) {
-        self._start = '(' + self._buffered.pop();
+        self._start = concatKey('(', self._buffered.pop());
       } else if (!self._values) {
-        self._start = '(' + self._buffered[self._buffered.length-1];
+        self._start = concatKey('(', self._buffered[self._buffered.length-1]);
       } else {
-        self._start = '(' + self._buffered[self._buffered.length-2];
+        self._start = concatKey('(', self._buffered[self._buffered.length-2]);
       }
     }
     self._shift(callback);


### PR DESCRIPTION
…//github.com/hmalphettes/redisdown/issues/17

There was a problem in the iterator. Similar to what I already solved.

When the iterator tries to remember it's current position it concats a string to a buffer, which results in a buffer to string serialization that redis can't understand.

The solution was to use `concatKey` again.

It works and passes all tests.