### PR TITLE
add .prefix options to batch()

### DIFF
--- a/test/batch-prefix-test.js
+++ b/test/batch-prefix-test.js
@@ -1,0 +1,65 @@
+'use strict';
+var db1, db2, db3;
+
+module.exports.setUp = function (redisdown, test, testCommon) {
+  test('setUp common', testCommon.setUp);
+};
+
+module.exports.args = function (redisdown, test, testCommon) {
+  test('batch prefix across redisdown instances', function (t) {
+    db1 = redisdown(testCommon.location());
+    db2 = redisdown(testCommon.location());
+    db3 = redisdown(testCommon.location());
+    db1.open({}, function (e) {
+      t.notOk(e, 'no error');
+      db2.open({}, function (e) {
+        t.notOk(e, 'no error');
+        db3.open({}, function (e) {
+          t.notOk(e, 'no error');
+          db1.batch([
+            {type: 'put', key: 'foo1', value: 'bar1'},
+            {type: 'put', key: 'foo2', value: 'bar2', prefix: db2},
+            {type: 'put', key: 'foo3', value: 'bar3', prefix: db3.location},
+          ], function (e) {
+            t.notOk(e, 'no error');
+            db1.get('foo1', {asBuffer: false}, function (e, val) {
+              t.notOk(e, 'no error');
+              t.equal(val, 'bar1');
+              db2.get('foo2', {asBuffer: false}, function (e, val) {
+                t.notOk(e, 'no error');
+                t.equal(val, 'bar2');
+                db3.get('foo3', {asBuffer: false}, function (e, val) {
+                  t.notOk(e, 'no error');
+                  t.equal(val, 'bar3');
+                  t.end();
+                })
+              })
+            })
+          });
+        });
+      });
+    });
+  })
+};
+
+module.exports.tearDown = function (test, testCommon) {
+  test('tearDown', function (t) {
+    db1.close(function (e) {
+      t.notOk(e, 'no error');
+      db2.close(function (e) {
+        t.notOk(e, 'no error');
+        db3.close(function (e) {
+          t.notOk(e, 'no error');
+          testCommon.tearDown(t);
+        });
+      });
+    });
+  });
+};
+
+module.exports.all = function (redisdown, test, testCommon) {
+  module.exports.setUp(redisdown, test, testCommon);
+  module.exports.args(redisdown, test, testCommon);
+  module.exports.tearDown(test, testCommon);
+};
+

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ var testBuffer = new Buffer('foo');
 
 /*** redis client management */
 require('./redis-client-test').all(leveljs, tape, testCommon);
+require('./batch-prefix-test').all(leveljs, tape, testCommon);
 
 /*** compatibility with basic LevelDOWN API ***/
 require('abstract-leveldown/abstract/leveldown-test').args(leveljs, tape, testCommon);


### PR DESCRIPTION
Thanks for the great module!

I am looking into adding [level-sublevel](https://github.com/dominictarr/level-sublevel#batches) convention of batch `.prefix` options.

Since Redis MULTI works across key space, supporting batch across Redisdown instances are basically changing the location mapping.

```js
var dbA = levelup('!a!', { db: redisdown })
var dbB = levelup('!b!', { db: redisdown })

dbA.batch([
  {key: 'foo', value: 'a', type: 'put'},
  {key: 'foo', value: 'b', type: 'put', prefix: dbB } // options.prefix
], function (err) {
  dbA.get('foo', function (err, val) {
    console.log(val) // a
  });
  dbB.get('foo', function (err, val) {
    console.log(val) // b
  });
})
```

This is definite not a standard leveldown feature, but its more idiomatic to the Redis data structure. What do you think?