### PR TITLE
Pin abstract-leveldown to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "redis"
   ],
   "dependencies": {
-    "abstract-leveldown": "*",
+    "abstract-leveldown": "2.4.1",
     "redis": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey @hmalphettes !

`redisdown` currently only supports abstract-leveldown <= 2.4.1. That's why the CI is failing on master.

I'll try to help getting redisdown to work with more recent versions of abstract-leveldown, which could mean support for levelup 2.x as well.

In the meantime, here is fix that will save developers some trouble. :)