### PR TITLE
Add reproducible example of an option not passed on

### DIFF
--- a/test/open-with-password/Dockerfile
+++ b/test/open-with-password/Dockerfile
@@ -1,0 +1,3 @@
+FROM redis
+COPY redis.conf /usr/local/etc/redis/redis.conf
+CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/test/open-with-password/open-with-password.js
+++ b/test/open-with-password/open-with-password.js
@@ -1,0 +1,14 @@
+const redisdown = require('../..');
+
+const db = redisdown('redis://localhost:6379');
+
+// This open does fail with "Authentication required".
+// If the `redisIdOptions` include 'password' in `_makeRedisId`, then it works.
+db.open({ password: "mypassword" }, function(e) {
+    console.log("Opened");
+    console.log(e);
+});
+db.close(function (e) {
+    console.log("Closed");
+    console.log(e);
+});

--- a/test/open-with-password/redis.conf
+++ b/test/open-with-password/redis.conf
@@ -1,0 +1,1 @@
+requirepass mypassword

--- a/test/open-with-password/start-redis-container.sh
+++ b/test/open-with-password/start-redis-container.sh
@@ -1,0 +1,2 @@
+docker build -t password-protected-redis .
+docker run -p 6379:6379 -d password-protected-redis


### PR DESCRIPTION
This PR reproduces the issue https://github.com/hmalphettes/redisdown/issues/37 .

1. Build and run password-protected redis container: `./test/open-with-password/start-redis-container.sh`.
2. Run `node ./test/open-with-password/open-with-password.js`.

The second command fails with the current version of redisdown.
If the `_makeRedisId` function is adjusted (adding "password" to the array or merging the options with the to be added options for example), then it successfully opens and closes.